### PR TITLE
Connect fix

### DIFF
--- a/lib/AnyEvent/OWNet.pm
+++ b/lib/AnyEvent/OWNet.pm
@@ -245,6 +245,7 @@ sub all_cv {
   $self->{all_cv} = shift if @_;
   unless ($self->{all_cv}) {
     $self->{all_cv} = AnyEvent->condvar;
+    $self->{all_cv}->cb( sub { print STDERR "all_cv done\n" } ) if DEBUG;
   }
   $self->{all_cv};
 }
@@ -284,6 +285,7 @@ sub connect {
   my $cv;
   if (@_) {
     $cv = AnyEvent->condvar;
+    $cv->cb( sub { print STDERR "connect_cv done\n" } ) if DEBUG;
     push @{$self->{connect_queue}}, [ $cv, @_ ];
   }
 


### PR DESCRIPTION
connect() did prevent the per-command condvar to be send() as _run_cmd returned either the connect() or per command condvar.

In other words: This caused the condvar of the first cmd on a new connection to be ignored.

I'm not sure If I fixed it "the right way", though...

I've also had trouble building from master branch... so my testing was based on build/master before  I rebased to master. Hopefully I got everything straight.
